### PR TITLE
Update typings to 2.0.1

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,5 +6,7 @@ export function blankNode(value?: string): RDF.BlankNode;
 export function literal(value: string, languageOrDatatype?: string | RDF.NamedNode): RDF.Literal;
 export function variable(value: string): RDF.Variable;
 export function defaultGraph(): RDF.DefaultGraph;
-export function triple(subject: RDF.Term, predicate: RDF.Term, object: RDF.Term): RDF.Quad;
-export function quad(subject: RDF.Term, predicate: RDF.Term, object: RDF.Term, graph?: RDF.Term): RDF.Quad;
+export function triple<Q extends RDF.BaseQuad = RDF.Quad>(
+  subject: Q['subject'], predicate: Q['predicate'], object: Q['object']): Q;
+export function quad<Q extends RDF.BaseQuad = RDF.Quad>(
+  subject: Q['subject'], predicate: Q['predicate'], object: Q['object'], graph?: Q['graph']): Q;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "url": "https://github.com/rdfjs/data-model/issues"
   },
   "homepage": "https://github.com/rdfjs/data-model",
-  "dependencies": {},
+  "dependencies": {
+    "@types/rdf-js": "^2.0.1"
+  },
   "devDependencies": {
     "browserify": "^16.2.2",
     "mocha": "^5.2.0",


### PR DESCRIPTION
The RDFJS typings were recently updated. This PR updates the typings of this project to be compatible with this update.

This also makes `@types/rdf-js` a dependency of this package, as [suggested by the TypeScript developers](https://github.com/Microsoft/types-publisher/issues/81). (In short, this makes it easier to work with the typings, without too much overhead in package size, as typings are small)