### PR TITLE
make typings dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,10 +28,8 @@
     "url": "https://github.com/rdfjs-base/data-model/issues"
   },
   "homepage": "https://github.com/rdfjs-base/data-model",
-  "dependencies": {
-    "@types/rdf-js": "^2.0.1"
-  },
   "devDependencies": {
+    "@types/rdf-js": "^2.0.1",
     "browserify": "^16.2.2",
     "mocha": "^5.2.0",
     "standard": "^11.0.1"


### PR DESCRIPTION
I came to realise that it should be solely up to the end consumer to install `@types` dependencies.

Now that `@types/rdf-js` turned `3.0` it is easy to install multiple versions in `node_modules`, which typescript does not like and will complain in some scenarios.

cc @rubensworks @elf-pavlik