### PR TITLE
Overhaul - no prototypes

### DIFF
--- a/dist/rdf-data-model.js
+++ b/dist/rdf-data-model.js
@@ -12,12 +12,9 @@ class BlankNode {
   equals (other) {
     return !!other && other.termType === this.termType && other.value === this.value
   }
-
-  get termType () {
-    return 'BlankNode'
-  }
 }
 
+BlankNode.prototype.termType = 'BlankNode'
 BlankNode.nextId = 0
 
 module.exports = BlankNode
@@ -81,18 +78,13 @@ module.exports = {
 
 },{"./blank-node":2,"./default-graph":4,"./literal":5,"./named-node":6,"./quad":7,"./variable":8}],4:[function(require,module,exports){
 class DefaultGraph {
-  get value () {
-    return ''
-  }
-
   equals (other) {
     return !!other && other.termType === this.termType
   }
-
-  get termType () {
-    return 'DefaultGraph'
-  }
 }
+
+DefaultGraph.prototype.termType = 'DefaultGraph'
+DefaultGraph.prototype.value = ''
 
 module.exports = DefaultGraph
 
@@ -117,12 +109,9 @@ class Literal {
     return !!other && other.termType === this.termType && other.value === this.value &&
       other.language === this.language && other.datatype.equals(this.datatype)
   }
-
-  get termType () {
-    return 'Literal'
-  }
 }
 
+Literal.prototype.termType = 'Literal'
 Literal.langStringDatatype = new NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#langString')
 Literal.stringDatatype = new NamedNode('http://www.w3.org/2001/XMLSchema#string')
 
@@ -137,11 +126,9 @@ class NamedNode {
   equals (other) {
     return !!other && other.termType === this.termType && other.value === this.value
   }
-
-  get termType () {
-    return 'NamedNode'
-  }
 }
+
+NamedNode.prototype.termType = 'NamedNode'
 
 module.exports = NamedNode
 
@@ -161,14 +148,6 @@ class Quad {
     }
   }
 
-  static get value() {
-    return ''
-  }
-
-  static get termType() {
-    return 'Quad'
-  }
-
   equals (other) {
     // `|| !other.termType` is for backwards-compatibility with old factories without RDF* support.
     return !!other && (other.termType === 'Quad' || !other.termType) &&
@@ -176,6 +155,9 @@ class Quad {
       other.object.equals(this.object) && other.graph.equals(this.graph)
   }
 }
+
+Quad.prototype.termType = 'Quad'
+Quad.prototype.value = ''
 
 module.exports = Quad
 
@@ -188,11 +170,9 @@ class Variable {
   equals (other) {
     return !!other && other.termType === this.termType && other.value === this.value
   }
-
-  get termType () {
-    return 'Variable'
-  }
 }
+
+Variable.prototype.termType = 'Variable'
 
 module.exports = Variable
 

--- a/lib/blank-node.js
+++ b/lib/blank-node.js
@@ -6,12 +6,9 @@ class BlankNode {
   equals (other) {
     return !!other && other.termType === this.termType && other.value === this.value
   }
-
-  get termType () {
-    return 'BlankNode'
-  }
 }
 
+BlankNode.prototype.termType = 'BlankNode'
 BlankNode.nextId = 0
 
 module.exports = BlankNode

--- a/lib/blank-node.js
+++ b/lib/blank-node.js
@@ -1,12 +1,16 @@
-function BlankNode (id) {
-  this.value = id || ('b' + (++BlankNode.nextId))
-}
+class BlankNode {
+  constructor (id) {
+    this.value = id || ('b' + (++BlankNode.nextId))
+  }
 
-BlankNode.prototype.equals = function (other) {
-  return !!other && other.termType === this.termType && other.value === this.value
-}
+  equals (other) {
+    return !!other && other.termType === this.termType && other.value === this.value
+  }
 
-BlankNode.prototype.termType = 'BlankNode'
+  get termType () {
+    return 'BlankNode'
+  }
+}
 
 BlankNode.nextId = 0
 

--- a/lib/data-factory.js
+++ b/lib/data-factory.js
@@ -5,44 +5,51 @@ var NamedNode = require('./named-node')
 var Quad = require('./quad')
 var Variable = require('./variable')
 
-function DataFactory () {}
-
-DataFactory.namedNode = function (value) {
+function namedNode (value) {
   return new NamedNode(value)
 }
 
-DataFactory.blankNode = function (value) {
+const defaultGraphInstance = new DefaultGraph()
+
+function blankNode (value) {
   return new BlankNode(value)
 }
 
-DataFactory.literal = function (value, languageOrDatatype) {
+function literal (value, languageOrDatatype) {
   if (typeof languageOrDatatype === 'string') {
     if (languageOrDatatype.indexOf(':') === -1) {
       return new Literal(value, languageOrDatatype)
     }
 
-    return new Literal(value, null, DataFactory.namedNode(languageOrDatatype))
+    return new Literal(value, null, namedNode(languageOrDatatype))
   }
 
   return new Literal(value, null, languageOrDatatype)
 }
 
-DataFactory.defaultGraph = function () {
-  return DataFactory.defaultGraphInstance
+function defaultGraph () {
+  return defaultGraphInstance
 }
 
-DataFactory.variable = function (value) {
+function variable (value) {
   return new Variable(value)
 }
 
-DataFactory.triple = function (subject, predicate, object) {
-  return DataFactory.quad(subject, predicate, object)
+function quad (subject, predicate, object, graph) {
+  return new Quad(subject, predicate, object, graph || defaultGraphInstance)
 }
 
-DataFactory.quad = function (subject, predicate, object, graph) {
-  return new Quad(subject, predicate, object, graph || DataFactory.defaultGraphInstance)
+function triple (subject, predicate, object) {
+  return quad(subject, predicate, object)
 }
 
-DataFactory.defaultGraphInstance = new DefaultGraph()
-
-module.exports = DataFactory
+module.exports = {
+  namedNode,
+  blankNode,
+  literal,
+  defaultGraph,
+  defaultGraphInstance,
+  variable,
+  quad,
+  triple
+}

--- a/lib/default-graph.js
+++ b/lib/default-graph.js
@@ -1,11 +1,15 @@
-function DefaultGraph () {
-  this.value = ''
-}
+class DefaultGraph {
+  get value () {
+    return ''
+  }
 
-DefaultGraph.prototype.equals = function (other) {
-  return !!other && other.termType === this.termType
-}
+  equals (other) {
+    return !!other && other.termType === this.termType
+  }
 
-DefaultGraph.prototype.termType = 'DefaultGraph'
+  get termType () {
+    return 'DefaultGraph'
+  }
+}
 
 module.exports = DefaultGraph

--- a/lib/default-graph.js
+++ b/lib/default-graph.js
@@ -1,15 +1,10 @@
 class DefaultGraph {
-  get value () {
-    return ''
-  }
-
   equals (other) {
     return !!other && other.termType === this.termType
   }
-
-  get termType () {
-    return 'DefaultGraph'
-  }
 }
+
+DefaultGraph.prototype.termType = 'DefaultGraph'
+DefaultGraph.prototype.value = ''
 
 module.exports = DefaultGraph

--- a/lib/literal.js
+++ b/lib/literal.js
@@ -1,24 +1,29 @@
 var NamedNode = require('./named-node')
 
-function Literal (value, language, datatype) {
-  this.value = value
-  this.datatype = Literal.stringDatatype
-  this.language = ''
+class Literal {
+  constructor (value, language, datatype) {
+    this.value = value
+    this.datatype = Literal.stringDatatype
+    this.language = ''
 
-  if (language) {
-    this.language = language
-    this.datatype = Literal.langStringDatatype
-  } else if (datatype) {
-    this.datatype = datatype
+    if (language) {
+      this.language = language
+      this.datatype = Literal.langStringDatatype
+    } else if (datatype) {
+      this.datatype = datatype
+    }
+  }
+
+  equals (other) {
+    return !!other && other.termType === this.termType && other.value === this.value &&
+      other.language === this.language && other.datatype.equals(this.datatype)
+  }
+
+  get termType () {
+    return 'Literal'
   }
 }
 
-Literal.prototype.equals = function (other) {
-  return !!other && other.termType === this.termType && other.value === this.value &&
-    other.language === this.language && other.datatype.equals(this.datatype)
-}
-
-Literal.prototype.termType = 'Literal'
 Literal.langStringDatatype = new NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#langString')
 Literal.stringDatatype = new NamedNode('http://www.w3.org/2001/XMLSchema#string')
 

--- a/lib/literal.js
+++ b/lib/literal.js
@@ -18,12 +18,9 @@ class Literal {
     return !!other && other.termType === this.termType && other.value === this.value &&
       other.language === this.language && other.datatype.equals(this.datatype)
   }
-
-  get termType () {
-    return 'Literal'
-  }
 }
 
+Literal.prototype.termType = 'Literal'
 Literal.langStringDatatype = new NamedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#langString')
 Literal.stringDatatype = new NamedNode('http://www.w3.org/2001/XMLSchema#string')
 

--- a/lib/named-node.js
+++ b/lib/named-node.js
@@ -6,10 +6,8 @@ class NamedNode {
   equals (other) {
     return !!other && other.termType === this.termType && other.value === this.value
   }
-
-  get termType () {
-    return 'NamedNode'
-  }
 }
+
+NamedNode.prototype.termType = 'NamedNode'
 
 module.exports = NamedNode

--- a/lib/named-node.js
+++ b/lib/named-node.js
@@ -1,11 +1,15 @@
-function NamedNode (iri) {
-  this.value = iri
-}
+class NamedNode {
+  constructor (iri) {
+    this.value = iri
+  }
 
-NamedNode.prototype.equals = function (other) {
-  return !!other && other.termType === this.termType && other.value === this.value
-}
+  equals (other) {
+    return !!other && other.termType === this.termType && other.value === this.value
+  }
 
-NamedNode.prototype.termType = 'NamedNode'
+  get termType () {
+    return 'NamedNode'
+  }
+}
 
 module.exports = NamedNode

--- a/lib/quad.js
+++ b/lib/quad.js
@@ -1,25 +1,32 @@
 var DefaultGraph = require('./default-graph')
 
-function Quad (subject, predicate, object, graph) {
-  this.subject = subject
-  this.predicate = predicate
-  this.object = object
+class Quad {
+  constructor (subject, predicate, object, graph) {
+    this.subject = subject
+    this.predicate = predicate
+    this.object = object
 
-  if (graph) {
-    this.graph = graph
-  } else {
-    this.graph = new DefaultGraph()
+    if (graph) {
+      this.graph = graph
+    } else {
+      this.graph = new DefaultGraph()
+    }
+  }
+
+  get value () {
+    return ''
+  }
+
+  get termType () {
+    return 'Quad'
+  }
+
+  equals (other) {
+    // `|| !other.termType` is for backwards-compatibility with old factories without RDF* support.
+    return !!other && (other.termType === 'Quad' || !other.termType) &&
+      other.subject.equals(this.subject) && other.predicate.equals(this.predicate) &&
+      other.object.equals(this.object) && other.graph.equals(this.graph)
   }
 }
-
-Quad.prototype.equals = function (other) {
-  // `|| !other.termType` is for backwards-compatibility with old factories without RDF* support.
-  return !!other && (other.termType === 'Quad' || !other.termType) &&
-    other.subject.equals(this.subject) && other.predicate.equals(this.predicate) &&
-    other.object.equals(this.object) && other.graph.equals(this.graph)
-}
-
-Quad.prototype.termType = 'Quad'
-Quad.prototype.value = ''
 
 module.exports = Quad

--- a/lib/quad.js
+++ b/lib/quad.js
@@ -13,14 +13,6 @@ class Quad {
     }
   }
 
-  get value () {
-    return ''
-  }
-
-  get termType () {
-    return 'Quad'
-  }
-
   equals (other) {
     // `|| !other.termType` is for backwards-compatibility with old factories without RDF* support.
     return !!other && (other.termType === 'Quad' || !other.termType) &&
@@ -28,5 +20,8 @@ class Quad {
       other.object.equals(this.object) && other.graph.equals(this.graph)
   }
 }
+
+Quad.prototype.termType = 'Quad'
+Quad.prototype.value = ''
 
 module.exports = Quad

--- a/lib/variable.js
+++ b/lib/variable.js
@@ -6,10 +6,8 @@ class Variable {
   equals (other) {
     return !!other && other.termType === this.termType && other.value === this.value
   }
-
-  get termType () {
-    return 'Variable'
-  }
 }
+
+Variable.prototype.termType = 'Variable'
 
 module.exports = Variable

--- a/lib/variable.js
+++ b/lib/variable.js
@@ -1,11 +1,15 @@
-function Variable (name) {
-  this.value = name
-}
+class Variable {
+  constructor (name) {
+    this.value = name
+  }
 
-Variable.prototype.equals = function (other) {
-  return !!other && other.termType === this.termType && other.value === this.value
-}
+  equals (other) {
+    return !!other && other.termType === this.termType && other.value === this.value
+  }
 
-Variable.prototype.termType = 'Variable'
+  get termType () {
+    return 'Variable'
+  }
+}
 
 module.exports = Variable

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
   },
   "devDependencies": {
     "browserify": "^16.2.2",
-    "mocha": "^5.2.0",
-    "standard": "^11.0.1"
+    "mocha": "^8.1.1",
+    "standard": "^14.3.4"
   },
   "engines": {
     "node": ">=6"

--- a/test/blank-node.js
+++ b/test/blank-node.js
@@ -7,65 +7,65 @@ var assert = require('assert')
 function runTests (DataFactory) {
   describe('.blankNode', function () {
     it('should be a static method', function () {
-      assert.equal(typeof DataFactory.blankNode, 'function')
+      assert.strictEqual(typeof DataFactory.blankNode, 'function')
     })
 
     it('should create an object with a termType property that contains the value "BlankNode"', function () {
       var term = DataFactory.blankNode()
 
-      assert.equal(term.termType, 'BlankNode')
+      assert.strictEqual(term.termType, 'BlankNode')
     })
 
     it('should create an object with a value property that contains a unique identifier', function () {
       var term1 = DataFactory.blankNode()
       var term2 = DataFactory.blankNode()
 
-      assert.notEqual(term1.value, term2.value)
+      assert.notStrictEqual(term1.value, term2.value)
     })
 
     it('should create an object with a value property that contains the given identifier', function () {
       var id = 'b1'
       var term = DataFactory.blankNode(id)
 
-      assert.equal(term.value, id)
+      assert.strictEqual(term.value, id)
     })
 
     describe('.equals', function () {
       it('should be a method', function () {
         var term = DataFactory.blankNode()
 
-        assert.equal(typeof term.equals, 'function')
+        assert.strictEqual(typeof term.equals, 'function')
       })
 
       it('should return true if termType and value are equal', function () {
         var id = 'b1'
         var term = DataFactory.blankNode(id)
-        var mock = {termType: 'BlankNode', value: id}
+        var mock = { termType: 'BlankNode', value: id }
 
-        assert.equal(term.equals(mock), true)
+        assert.strictEqual(term.equals(mock), true)
       })
 
       it('should return false if termType is not equal', function () {
         var id = 'b1'
         var term = DataFactory.blankNode(id)
-        var mock = {termType: 'NamedNode', value: id}
+        var mock = { termType: 'NamedNode', value: id }
 
-        assert.equal(term.equals(mock), false)
+        assert.strictEqual(term.equals(mock), false)
       })
 
       it('should return false if value is not equal', function () {
         var id = 'b1'
         var term = DataFactory.blankNode(id)
-        var mock = {termType: 'BlankNode', value: id + '1'}
+        var mock = { termType: 'BlankNode', value: id + '1' }
 
-        assert.equal(term.equals(mock), false)
+        assert.strictEqual(term.equals(mock), false)
       })
 
       it('should return false if value is falsy', function () {
         var id = 'b1'
         var term = DataFactory.blankNode(id)
 
-        assert.equal(term.equals(null), false)
+        assert.strictEqual(term.equals(null), false)
       })
     })
   })

--- a/test/default-graph.js
+++ b/test/default-graph.js
@@ -7,46 +7,46 @@ var assert = require('assert')
 function runTests (DataFactory) {
   describe('.defaultGraph', function () {
     it('should be a static method', function () {
-      assert.equal(typeof DataFactory.defaultGraph, 'function')
+      assert.strictEqual(typeof DataFactory.defaultGraph, 'function')
     })
 
     it('should create an object with a termType property that contains the value "DefaultGraph"', function () {
       var term = DataFactory.defaultGraph()
 
-      assert.equal(term.termType, 'DefaultGraph')
+      assert.strictEqual(term.termType, 'DefaultGraph')
     })
 
     it('should create an object with a value property that contains an empty string', function () {
       var term = DataFactory.defaultGraph()
 
-      assert.equal(term.value, '')
+      assert.strictEqual(term.value, '')
     })
 
     describe('.equals', function () {
       it('should be a method', function () {
         var term = DataFactory.defaultGraph()
 
-        assert.equal(typeof term.equals, 'function')
+        assert.strictEqual(typeof term.equals, 'function')
       })
 
       it('should return true if termType and value are equal', function () {
         var term = DataFactory.defaultGraph()
-        var mock = {termType: 'DefaultGraph', value: ''}
+        var mock = { termType: 'DefaultGraph', value: '' }
 
-        assert.equal(term.equals(mock), true)
+        assert.strictEqual(term.equals(mock), true)
       })
 
       it('should return false if termType is not equal', function () {
         var term = DataFactory.defaultGraph()
-        var mock = {termType: 'NamedNode', value: ''}
+        var mock = { termType: 'NamedNode', value: '' }
 
-        assert.equal(term.equals(mock), false)
+        assert.strictEqual(term.equals(mock), false)
       })
 
       it('should return false if value is falsy', function () {
         var term = DataFactory.defaultGraph()
 
-        assert.equal(term.equals(null), false)
+        assert.strictEqual(term.equals(null), false)
       })
     })
   })

--- a/test/literal.js
+++ b/test/literal.js
@@ -7,27 +7,27 @@ var assert = require('assert')
 function runTests (DataFactory) {
   describe('.literal', function () {
     it('should be a static method', function () {
-      assert.equal(typeof DataFactory.literal, 'function')
+      assert.strictEqual(typeof DataFactory.literal, 'function')
     })
 
     it('should create an object with a termType property that contains the value "Literal"', function () {
       var term = DataFactory.literal()
 
-      assert.equal(term.termType, 'Literal')
+      assert.strictEqual(term.termType, 'Literal')
     })
 
     it('should create an object with a value property that contains the given string', function () {
       var string = 'example'
       var term = DataFactory.literal(string)
 
-      assert.equal(term.value, string)
+      assert.strictEqual(term.value, string)
     })
 
     it('should create an object with a language property that contains an empty string', function () {
       var string = 'example'
       var term = DataFactory.literal(string)
 
-      assert.equal(term.language, '')
+      assert.strictEqual(term.language, '')
     })
 
     it('should create an object with a language property that contains the given language string', function () {
@@ -35,15 +35,15 @@ function runTests (DataFactory) {
       var language = 'en'
       var term = DataFactory.literal(string, language)
 
-      assert.equal(term.language, language)
+      assert.strictEqual(term.language, language)
     })
 
     it('should create an object with a datatype property that contains a NamedNode with the value "http://www.w3.org/2001/XMLSchema#string"', function () {
       var string = 'example'
       var term = DataFactory.literal(string)
 
-      assert.equal(term.datatype.termType, 'NamedNode')
-      assert.equal(term.datatype.value, 'http://www.w3.org/2001/XMLSchema#string')
+      assert.strictEqual(term.datatype.termType, 'NamedNode')
+      assert.strictEqual(term.datatype.value, 'http://www.w3.org/2001/XMLSchema#string')
     })
 
     it('should create an object with a datatype property that contains a NamedNode with the value "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"', function () {
@@ -51,8 +51,8 @@ function runTests (DataFactory) {
       var language = 'en'
       var term = DataFactory.literal(string, language)
 
-      assert.equal(term.datatype.termType, 'NamedNode')
-      assert.equal(term.datatype.value, 'http://www.w3.org/1999/02/22-rdf-syntax-ns#langString')
+      assert.strictEqual(term.datatype.termType, 'NamedNode')
+      assert.strictEqual(term.datatype.value, 'http://www.w3.org/1999/02/22-rdf-syntax-ns#langString')
     })
 
     it('should create an object with a datatype property that contains a NamedNode with the given IRI', function () {
@@ -61,24 +61,24 @@ function runTests (DataFactory) {
       var datatypeNode = DataFactory.namedNode(datatypeIRI)
       var term = DataFactory.literal(string, datatypeNode)
 
-      assert.equal(term.datatype.termType, 'NamedNode')
-      assert.equal(term.datatype.value, datatypeIRI)
+      assert.strictEqual(term.datatype.termType, 'NamedNode')
+      assert.strictEqual(term.datatype.value, datatypeIRI)
     })
 
     it('should create an object with a datatype property that contains the given NamedNode', function () {
       var string = 'example'
-      var datatype = {termType: 'NamedNode', value: 'http://example.org'}
+      var datatype = { termType: 'NamedNode', value: 'http://example.org' }
       var term = DataFactory.literal(string, datatype)
 
-      assert.equal(term.datatype.termType, 'NamedNode')
-      assert.equal(term.datatype.value, datatype.value)
+      assert.strictEqual(term.datatype.termType, 'NamedNode')
+      assert.strictEqual(term.datatype.value, datatype.value)
     })
 
     describe('.equals', function () {
       it('should be a method', function () {
         var term = DataFactory.literal('')
 
-        assert.equal(typeof term.equals, 'function')
+        assert.strictEqual(typeof term.equals, 'function')
       })
 
       it('should return true if termType, value, language and datatype are equal', function () {
@@ -92,7 +92,7 @@ function runTests (DataFactory) {
           datatype: DataFactory.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#langString')
         }
 
-        assert.equal(term.equals(mock), true)
+        assert.strictEqual(term.equals(mock), true)
       })
 
       it('should return false if termType is not equal', function () {
@@ -106,7 +106,7 @@ function runTests (DataFactory) {
           datatype: DataFactory.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#langString')
         }
 
-        assert.equal(term.equals(mock), false)
+        assert.strictEqual(term.equals(mock), false)
       })
 
       it('should return false if value is not equal', function () {
@@ -120,7 +120,7 @@ function runTests (DataFactory) {
           datatype: DataFactory.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#langString')
         }
 
-        assert.equal(term.equals(mock), false)
+        assert.strictEqual(term.equals(mock), false)
       })
 
       it('should return false if language is not equal', function () {
@@ -134,7 +134,7 @@ function runTests (DataFactory) {
           datatype: DataFactory.namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#langString')
         }
 
-        assert.equal(term.equals(mock), false)
+        assert.strictEqual(term.equals(mock), false)
       })
 
       it('should return false if datatype is not equal', function () {
@@ -148,7 +148,7 @@ function runTests (DataFactory) {
           datatype: DataFactory.namedNode('http://example.org')
         }
 
-        assert.equal(term.equals(mock), false)
+        assert.strictEqual(term.equals(mock), false)
       })
 
       it('should return false if value is falsy', function () {
@@ -156,7 +156,7 @@ function runTests (DataFactory) {
         var language = 'en'
         var term = DataFactory.literal(string, language)
 
-        assert.equal(term.equals(null), false)
+        assert.strictEqual(term.equals(null), false)
       })
     })
   })

--- a/test/named-node.js
+++ b/test/named-node.js
@@ -7,21 +7,21 @@ var assert = require('assert')
 function runTests (DataFactory) {
   describe('.namedNode', function () {
     it('should be a static method', function () {
-      assert.equal(typeof DataFactory.namedNode, 'function')
+      assert.strictEqual(typeof DataFactory.namedNode, 'function')
     })
 
     it('should create an object with a termType property that contains the value "NamedNode"', function () {
       var iri = 'http://example.org'
       var term = DataFactory.namedNode(iri)
 
-      assert.equal(term.termType, 'NamedNode')
+      assert.strictEqual(term.termType, 'NamedNode')
     })
 
     it('should create an object with a value property that contains the given IRI', function () {
       var iri = 'http://example.org'
       var term = DataFactory.namedNode(iri)
 
-      assert.equal(term.value, iri)
+      assert.strictEqual(term.value, iri)
     })
 
     describe('.equals', function () {
@@ -29,38 +29,38 @@ function runTests (DataFactory) {
         var iri = 'http://example.org'
         var term = DataFactory.namedNode(iri)
 
-        assert.equal(typeof term.equals, 'function')
+        assert.strictEqual(typeof term.equals, 'function')
       })
 
       it('should return true if termType and value are equal', function () {
         var iri = 'http://example.org'
         var term = DataFactory.namedNode(iri)
-        var mock = {termType: 'NamedNode', value: iri}
+        var mock = { termType: 'NamedNode', value: iri }
 
-        assert.equal(term.equals(mock), true)
+        assert.strictEqual(term.equals(mock), true)
       })
 
       it('should return false if termType is not equal', function () {
         var iri = 'http://example.org'
         var term = DataFactory.namedNode(iri)
-        var mock = {termType: 'BlankNode', value: iri}
+        var mock = { termType: 'BlankNode', value: iri }
 
-        assert.equal(term.equals(mock), false)
+        assert.strictEqual(term.equals(mock), false)
       })
 
       it('should return false if value is not equal', function () {
         var iri = 'http://example.org'
         var term = DataFactory.namedNode(iri)
-        var mock = {termType: 'NamedNode', value: iri + '1'}
+        var mock = { termType: 'NamedNode', value: iri + '1' }
 
-        assert.equal(term.equals(mock), false)
+        assert.strictEqual(term.equals(mock), false)
       })
 
       it('should return false if value is falsy', function () {
         var iri = 'http://example.org'
         var term = DataFactory.namedNode(iri)
 
-        assert.equal(term.equals(null), false)
+        assert.strictEqual(term.equals(null), false)
       })
     })
   })

--- a/test/quad.js
+++ b/test/quad.js
@@ -7,7 +7,7 @@ var assert = require('assert')
 function runTests (DataFactory) {
   describe('.quad', function () {
     it('should be a static method', function () {
-      assert.equal(typeof DataFactory.quad, 'function')
+      assert.strictEqual(typeof DataFactory.quad, 'function')
     })
 
     it('should create an object with .subject, .predicate, .object and .graph with the given values', function () {
@@ -17,13 +17,13 @@ function runTests (DataFactory) {
       var graph = DataFactory.namedNode('http://example.org/graph')
       var quad = DataFactory.quad(subject, predicate, object, graph)
 
-      assert.equal(subject.equals(quad.subject), true)
-      assert.equal(predicate.equals(quad.predicate), true)
-      assert.equal(object.equals(quad.object), true)
-      assert.equal(graph.equals(quad.graph), true)
+      assert.strictEqual(subject.equals(quad.subject), true)
+      assert.strictEqual(predicate.equals(quad.predicate), true)
+      assert.strictEqual(object.equals(quad.object), true)
+      assert.strictEqual(graph.equals(quad.graph), true)
 
-      assert.equal(quad.termType, 'Quad')
-      assert.equal(quad.value, '')
+      assert.strictEqual(quad.termType, 'Quad')
+      assert.strictEqual(quad.value, '')
     })
 
     it('should create an object .graph set to DefaultGraph if the argument isn\'t given', function () {
@@ -33,10 +33,10 @@ function runTests (DataFactory) {
       var graph = DataFactory.defaultGraph()
       var quad = DataFactory.quad(subject, predicate, object)
 
-      assert.equal(quad.graph.equals(graph), true)
+      assert.strictEqual(quad.graph.equals(graph), true)
 
-      assert.equal(quad.termType, 'Quad')
-      assert.equal(quad.value, '')
+      assert.strictEqual(quad.termType, 'Quad')
+      assert.strictEqual(quad.value, '')
     })
 
     describe('.equals', function () {
@@ -48,7 +48,7 @@ function runTests (DataFactory) {
         var quad1 = DataFactory.quad(subject, predicate, object, graph)
         var quad2 = DataFactory.quad(subject, predicate, object, graph)
 
-        assert.equal(quad1.equals(quad2), true)
+        assert.strictEqual(quad1.equals(quad2), true)
       })
 
       it('should return true even if the other equal quad is from a non-RDF* factory', function () {
@@ -59,7 +59,7 @@ function runTests (DataFactory) {
         var quad1 = DataFactory.quad(subject, predicate, object, graph)
         var quad2 = { subject, predicate, object, graph }
 
-        assert.equal(quad1.equals(quad2), true)
+        assert.strictEqual(quad1.equals(quad2), true)
       })
 
       it('should return false if the subject of the other quad is not the same', function () {
@@ -71,7 +71,7 @@ function runTests (DataFactory) {
         var quad1 = DataFactory.quad(subject1, predicate, object, graph)
         var quad2 = DataFactory.quad(subject2, predicate, object, graph)
 
-        assert.equal(quad1.equals(quad2), false)
+        assert.strictEqual(quad1.equals(quad2), false)
       })
 
       it('should return false even if the other non-equal quad is from a non-RDF* factory', function () {
@@ -83,7 +83,7 @@ function runTests (DataFactory) {
         var quad1 = DataFactory.quad(subject1, predicate, object, graph)
         var quad2 = { subject: subject2, predicate, object, graph }
 
-        assert.equal(quad1.equals(quad2), false)
+        assert.strictEqual(quad1.equals(quad2), false)
       })
 
       it('should return false if the predicate of the other quad is not the same', function () {
@@ -95,7 +95,7 @@ function runTests (DataFactory) {
         var quad1 = DataFactory.quad(subject, predicate1, object, graph)
         var quad2 = DataFactory.quad(subject, predicate2, object, graph)
 
-        assert.equal(quad1.equals(quad2), false)
+        assert.strictEqual(quad1.equals(quad2), false)
       })
 
       it('should return false if the object of the other quad is not the same', function () {
@@ -107,7 +107,7 @@ function runTests (DataFactory) {
         var quad1 = DataFactory.quad(subject, predicate, object1, graph)
         var quad2 = DataFactory.quad(subject, predicate, object2, graph)
 
-        assert.equal(quad1.equals(quad2), false)
+        assert.strictEqual(quad1.equals(quad2), false)
       })
 
       it('should return false if the graph of the other quad is not the same', function () {
@@ -119,7 +119,7 @@ function runTests (DataFactory) {
         var quad1 = DataFactory.quad(subject, predicate, object, graph1)
         var quad2 = DataFactory.quad(subject, predicate, object, graph2)
 
-        assert.equal(quad1.equals(quad2), false)
+        assert.strictEqual(quad1.equals(quad2), false)
       })
 
       it('should return false if value is falsy', function () {
@@ -129,7 +129,7 @@ function runTests (DataFactory) {
         var graph = DataFactory.namedNode('http://example.org/graph')
         var quad = DataFactory.quad(subject, predicate, object, graph)
 
-        assert.equal(quad.equals(null), false)
+        assert.strictEqual(quad.equals(null), false)
       })
 
       it('should return false if value is another term', function () {
@@ -139,11 +139,11 @@ function runTests (DataFactory) {
         var graph = DataFactory.namedNode('http://example.org/graph')
         var quad = DataFactory.quad(subject, predicate, object, graph)
 
-        assert.equal(quad.equals(DataFactory.namedNode('http://example.org/subject')), false)
-        assert.equal(quad.equals(DataFactory.literal('abc')), false)
-        assert.equal(quad.equals(DataFactory.variable('var')), false)
-        assert.equal(quad.equals(DataFactory.blankNode('bnode')), false)
-        assert.equal(quad.equals(DataFactory.defaultGraph()), false)
+        assert.strictEqual(quad.equals(DataFactory.namedNode('http://example.org/subject')), false)
+        assert.strictEqual(quad.equals(DataFactory.literal('abc')), false)
+        assert.strictEqual(quad.equals(DataFactory.variable('var')), false)
+        assert.strictEqual(quad.equals(DataFactory.blankNode('bnode')), false)
+        assert.strictEqual(quad.equals(DataFactory.defaultGraph()), false)
       })
 
       it('should return true for an equal nested quad', function () {
@@ -163,7 +163,7 @@ function runTests (DataFactory) {
         var quad1 = DataFactory.quad(subject, predicate, object, graph)
         var quad2 = DataFactory.quad(subject, predicate, object, graph)
 
-        assert.equal(quad1.equals(quad2), true)
+        assert.strictEqual(quad1.equals(quad2), true)
       })
     })
   })

--- a/test/triple.js
+++ b/test/triple.js
@@ -7,7 +7,7 @@ var assert = require('assert')
 function runTests (DataFactory) {
   describe('.triple', function () {
     it('should be a static method', function () {
-      assert.equal(typeof DataFactory.triple, 'function')
+      assert.strictEqual(typeof DataFactory.triple, 'function')
     })
 
     it('should create an object with .subject, .predicate and .object with the given values and .graph set to DefaultGraph', function () {
@@ -16,10 +16,10 @@ function runTests (DataFactory) {
       var object = DataFactory.namedNode('http://example.org/object')
       var triple = DataFactory.triple(subject, predicate, object)
 
-      assert.equal(subject.equals(triple.subject), true)
-      assert.equal(predicate.equals(triple.predicate), true)
-      assert.equal(object.equals(triple.object), true)
-      assert.equal(DataFactory.defaultGraph().equals(triple.graph), true)
+      assert.strictEqual(subject.equals(triple.subject), true)
+      assert.strictEqual(predicate.equals(triple.predicate), true)
+      assert.strictEqual(object.equals(triple.object), true)
+      assert.strictEqual(DataFactory.defaultGraph().equals(triple.graph), true)
     })
 
     it('should ignore a 4th parameter and always use DefaultGraph', function () {
@@ -29,7 +29,7 @@ function runTests (DataFactory) {
       var graph = DataFactory.namedNode('http://example.org/graph')
       var triple = DataFactory.triple(subject, predicate, object, graph)
 
-      assert.equal(DataFactory.defaultGraph().equals(triple.graph), true)
+      assert.strictEqual(DataFactory.defaultGraph().equals(triple.graph), true)
     })
 
     describe('.equals', function () {
@@ -40,7 +40,7 @@ function runTests (DataFactory) {
         var triple1 = DataFactory.triple(subject, predicate, object)
         var triple2 = DataFactory.triple(subject, predicate, object)
 
-        assert.equal(triple1.equals(triple2), true)
+        assert.strictEqual(triple1.equals(triple2), true)
       })
 
       it('should return false if the subject of the other triple is not the same', function () {
@@ -51,7 +51,7 @@ function runTests (DataFactory) {
         var triple1 = DataFactory.triple(subject1, predicate, object)
         var triple2 = DataFactory.triple(subject2, predicate, object)
 
-        assert.equal(triple1.equals(triple2), false)
+        assert.strictEqual(triple1.equals(triple2), false)
       })
 
       it('should return false if the predicate of the other triple is not the same', function () {
@@ -62,7 +62,7 @@ function runTests (DataFactory) {
         var triple1 = DataFactory.triple(subject, predicate1, object)
         var triple2 = DataFactory.triple(subject, predicate2, object)
 
-        assert.equal(triple1.equals(triple2), false)
+        assert.strictEqual(triple1.equals(triple2), false)
       })
 
       it('should return false if the object of the other triple is not the same', function () {
@@ -73,7 +73,7 @@ function runTests (DataFactory) {
         var triple1 = DataFactory.triple(subject, predicate, object1)
         var triple2 = DataFactory.triple(subject, predicate, object2)
 
-        assert.equal(triple1.equals(triple2), false)
+        assert.strictEqual(triple1.equals(triple2), false)
       })
 
       it('should return false if the graph of the other quad is not the same', function () {
@@ -84,7 +84,7 @@ function runTests (DataFactory) {
         var triple = DataFactory.triple(subject, predicate, object)
         var quad = DataFactory.quad(subject, predicate, object, graph)
 
-        assert.equal(triple.equals(quad), false)
+        assert.strictEqual(triple.equals(quad), false)
       })
 
       it('should return false if value is falsy', function () {
@@ -93,7 +93,7 @@ function runTests (DataFactory) {
         var object = DataFactory.namedNode('http://example.org/object')
         var triple = DataFactory.triple(subject, predicate, object)
 
-        assert.equal(triple.equals(null), false)
+        assert.strictEqual(triple.equals(null), false)
       })
     })
   })

--- a/test/variable.js
+++ b/test/variable.js
@@ -12,59 +12,59 @@ function runTests (DataFactory) {
 
   describe('.variable', function () {
     it('should be a static method', function () {
-      assert.equal(typeof DataFactory.variable, 'function')
+      assert.strictEqual(typeof DataFactory.variable, 'function')
     })
 
     it('should create an object with a termType property that contains the value "Variable"', function () {
       var name = 'v'
       var term = DataFactory.variable(name)
 
-      assert.equal(term.termType, 'Variable')
+      assert.strictEqual(term.termType, 'Variable')
     })
 
     it('should create an object with a value property that contains the given name', function () {
       var name = 'v'
       var term = DataFactory.variable(name)
 
-      assert.equal(term.value, name)
+      assert.strictEqual(term.value, name)
     })
 
     describe('.equals', function () {
       it('should be a method', function () {
         var term = DataFactory.variable()
 
-        assert.equal(typeof term.equals, 'function')
+        assert.strictEqual(typeof term.equals, 'function')
       })
 
       it('should return true if termType and value are equal', function () {
         var name = 'v'
         var term = DataFactory.variable(name)
-        var mock = {termType: 'Variable', value: name}
+        var mock = { termType: 'Variable', value: name }
 
-        assert.equal(term.equals(mock), true)
+        assert.strictEqual(term.equals(mock), true)
       })
 
       it('should return false if termType is not equal', function () {
         var name = 'v'
         var term = DataFactory.variable(name)
-        var mock = {termType: 'NamedNode', value: name}
+        var mock = { termType: 'NamedNode', value: name }
 
-        assert.equal(term.equals(mock), false)
+        assert.strictEqual(term.equals(mock), false)
       })
 
       it('should return false if value is not equal', function () {
         var name = 'v'
         var term = DataFactory.variable(name)
-        var mock = {termType: 'Variable', value: name + '1'}
+        var mock = { termType: 'Variable', value: name + '1' }
 
-        assert.equal(term.equals(mock), false)
+        assert.strictEqual(term.equals(mock), false)
       })
 
       it('should return false if value is falsy', function () {
         var name = 'v'
         var term = DataFactory.variable(name)
 
-        assert.equal(term.equals(null), false)
+        assert.strictEqual(term.equals(null), false)
       })
     })
   })


### PR DESCRIPTION
First step for moving this package a little bit into the present

* [x] Replace all prototypes with ES classes
* [x] Update `standard` and `mocha`