### PR TITLE
Add support for RDF*

### DIFF
--- a/dist/rdf-data-model.js
+++ b/dist/rdf-data-model.js
@@ -137,9 +137,14 @@ function Quad (subject, predicate, object, graph) {
 }
 
 Quad.prototype.equals = function (other) {
-  return !!other && other.subject.equals(this.subject) && other.predicate.equals(this.predicate) &&
+  // `|| !other.termType` is for backwards-compatibility with old factories without RDF* support.
+  return !!other && (other.termType === 'Quad' || !other.termType) &&
+    other.subject.equals(this.subject) && other.predicate.equals(this.predicate) &&
     other.object.equals(this.object) && other.graph.equals(this.graph)
 }
+
+Quad.prototype.termType = 'Quad'
+Quad.prototype.value = ''
 
 module.exports = Quad
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 import * as RDF from "rdf-js";
 
 export const defaultGraphInstance: RDF.DefaultGraph;
-export function namedNode(value: string): RDF.NamedNode;
+export function namedNode<Iri extends string = string>(value: Iri): RDF.NamedNode<Iri>;
 export function blankNode(value?: string): RDF.BlankNode;
 export function literal(value: string, languageOrDatatype?: string | RDF.NamedNode): RDF.Literal;
 export function variable(value: string): RDF.Variable;

--- a/lib/quad.js
+++ b/lib/quad.js
@@ -13,8 +13,13 @@ function Quad (subject, predicate, object, graph) {
 }
 
 Quad.prototype.equals = function (other) {
-  return !!other && other.subject.equals(this.subject) && other.predicate.equals(this.predicate) &&
+  // `|| !other.termType` is for backwards-compatibility with old factories without RDF* support.
+  return !!other && (other.termType === 'Quad' || !other.termType) &&
+    other.subject.equals(this.subject) && other.predicate.equals(this.predicate) &&
     other.object.equals(this.object) && other.graph.equals(this.graph)
 }
+
+Quad.prototype.termType = 'Quad'
+Quad.prototype.value = ''
 
 module.exports = Quad

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/rdfjs-base/data-model",
   "dependencies": {
-    "@types/rdf-js": "^2.0.1"
+    "@types/rdf-js": "*"
   },
   "devDependencies": {
     "browserify": "^16.2.2",

--- a/test/quad.js
+++ b/test/quad.js
@@ -21,6 +21,9 @@ function runTests (DataFactory) {
       assert.equal(predicate.equals(quad.predicate), true)
       assert.equal(object.equals(quad.object), true)
       assert.equal(graph.equals(quad.graph), true)
+
+      assert.equal(quad.termType, 'Quad')
+      assert.equal(quad.value, '')
     })
 
     it('should create an object .graph set to DefaultGraph if the argument isn\'t given', function () {
@@ -31,6 +34,9 @@ function runTests (DataFactory) {
       var quad = DataFactory.quad(subject, predicate, object)
 
       assert.equal(quad.graph.equals(graph), true)
+
+      assert.equal(quad.termType, 'Quad')
+      assert.equal(quad.value, '')
     })
 
     describe('.equals', function () {
@@ -45,6 +51,17 @@ function runTests (DataFactory) {
         assert.equal(quad1.equals(quad2), true)
       })
 
+      it('should return true even if the other equal quad is from a non-RDF* factory', function () {
+        var subject = DataFactory.namedNode('http://example.org/subject')
+        var predicate = DataFactory.namedNode('http://example.org/predicate')
+        var object = DataFactory.namedNode('http://example.org/object')
+        var graph = DataFactory.namedNode('http://example.org/graph')
+        var quad1 = DataFactory.quad(subject, predicate, object, graph)
+        var quad2 = { subject, predicate, object, graph }
+
+        assert.equal(quad1.equals(quad2), true)
+      })
+
       it('should return false if the subject of the other quad is not the same', function () {
         var subject1 = DataFactory.namedNode('http://example.org/subject')
         var subject2 = DataFactory.namedNode('http://example.com/subject')
@@ -53,6 +70,18 @@ function runTests (DataFactory) {
         var graph = DataFactory.namedNode('http://example.org/graph')
         var quad1 = DataFactory.quad(subject1, predicate, object, graph)
         var quad2 = DataFactory.quad(subject2, predicate, object, graph)
+
+        assert.equal(quad1.equals(quad2), false)
+      })
+
+      it('should return false even if the other non-equal quad is from a non-RDF* factory', function () {
+        var subject1 = DataFactory.namedNode('http://example.org/subject')
+        var subject2 = DataFactory.namedNode('http://example.com/subject')
+        var predicate = DataFactory.namedNode('http://example.org/predicate')
+        var object = DataFactory.namedNode('http://example.org/object')
+        var graph = DataFactory.namedNode('http://example.org/graph')
+        var quad1 = DataFactory.quad(subject1, predicate, object, graph)
+        var quad2 = { subject: subject2, predicate, object, graph }
 
         assert.equal(quad1.equals(quad2), false)
       })
@@ -101,6 +130,40 @@ function runTests (DataFactory) {
         var quad = DataFactory.quad(subject, predicate, object, graph)
 
         assert.equal(quad.equals(null), false)
+      })
+
+      it('should return false if value is another term', function () {
+        var subject = DataFactory.namedNode('http://example.org/subject')
+        var predicate = DataFactory.namedNode('http://example.org/predicate')
+        var object = DataFactory.namedNode('http://example.org/object')
+        var graph = DataFactory.namedNode('http://example.org/graph')
+        var quad = DataFactory.quad(subject, predicate, object, graph)
+
+        assert.equal(quad.equals(DataFactory.namedNode('http://example.org/subject')), false)
+        assert.equal(quad.equals(DataFactory.literal('abc')), false)
+        assert.equal(quad.equals(DataFactory.variable('var')), false)
+        assert.equal(quad.equals(DataFactory.blankNode('bnode')), false)
+        assert.equal(quad.equals(DataFactory.defaultGraph()), false)
+      })
+
+      it('should return true for an equal nested quad', function () {
+        var subject = DataFactory.quad(
+          DataFactory.namedNode('http://example.org/subjectInner1'),
+          DataFactory.namedNode('http://example.org/predicateInner1'),
+          DataFactory.namedNode('http://example.org/objectInner1')
+        )
+        var predicate = DataFactory.namedNode('http://example.org/predicate')
+        var object = DataFactory.quad(
+          DataFactory.namedNode('http://example.org/subjectInner2'),
+          DataFactory.namedNode('http://example.org/predicateInner2'),
+          DataFactory.namedNode('http://example.org/objectInner2'),
+          DataFactory.namedNode('http://example.org/graphInner2')
+        )
+        var graph = DataFactory.namedNode('http://example.org/graph')
+        var quad1 = DataFactory.quad(subject, predicate, object, graph)
+        var quad2 = DataFactory.quad(subject, predicate, object, graph)
+
+        assert.equal(quad1.equals(quad2), true)
       })
     })
   })


### PR DESCRIPTION
This brings this package up to date with the latest RDF/JS data model spec.

As suggested by @tpluscode, I've made the dependency range of `@types/rdf-js` as `*` to avoid future versioning issues. This way we're in line with how DefinitelyTyped handles typings dependencies as well.

\cc @bergos