### PR TITLE
Tests: Always give a variable name to Variable constructor

### DIFF
--- a/test/variable.js
+++ b/test/variable.js
@@ -31,7 +31,7 @@ function runTests (DataFactory) {
 
     describe('.equals', function () {
       it('should be a method', function () {
-        var term = DataFactory.variable()
+        var term = DataFactory.variable('v')
 
         assert.equal(typeof term.equals, 'function')
       })


### PR DESCRIPTION
The RDF/JS variable constructor seems to require a variable name