### PR TITLE
Transpile to CommonJS, make it work in CommonJs as well.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,13 @@
   "description": "A basic implementation of the RDF/JS Data Model",
   "type": "module",
   "main": "index.js",
+  "exports": {
+    "require": "./dist/index.cjs",
+    "import": "./index.js"
+  },
   "scripts": {
-    "test": "stricter-standard && c8 --reporter=lcov --reporter=text mocha"
+    "test": "stricter-standard && c8 --reporter=lcov --reporter=text mocha",
+    "prepack": "tsup index.js --format cjs"
   },
   "bin": {
     "rdfjs-data-model-test": "./bin/test.js"
@@ -28,6 +33,8 @@
   "devDependencies": {
     "c8": "^9.1.0",
     "mocha": "^10.3.0",
-    "stricter-standard": "^0.3.0"
+    "stricter-standard": "^0.3.0",
+    "tsup": "^8.0.2",
+    "typescript": "^5.3.3"
   }
 }


### PR DESCRIPTION
```
const dataFactory = require('@rdfjs/data-model')
```
In order to make it work with typescript+commonJs, https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/rdfjs__data-model/package.json needs update as well:
```
{ 
  ...
  "exports": {
    "require": "",
    "import": ""
  },
}
```