### PR TITLE
fix: preserve direction when cloning directional literals via fromTerm

### DIFF
--- a/lib/fromTerm.js
+++ b/lib/fromTerm.js
@@ -12,7 +12,9 @@ function fromTerm (factory, original) {
   }
 
   if (original.termType === 'Literal') {
-    return factory.literal(original.value, original.language || factory.namedNode(original.datatype.value))
+    return factory.literal(original.value, original.language
+      ? { language: original.language, direction: original.direction }
+      : factory.namedNode(original.datatype.value))
   }
 
   if (original.termType === 'NamedNode') {

--- a/test/fromTerm.test.js
+++ b/test/fromTerm.test.js
@@ -43,6 +43,16 @@ function runTests ({ factory, mocha }) {
       notStrictEqual(term, original)
     })
 
+    it('should create a clone of the given Literal with direction', () => {
+      const original = factory.literal('example', { language: 'en', direction: 'rtl' })
+
+      const term = factory.fromTerm(original)
+
+      strictEqual(term.equals(original), true)
+      strictEqual(term.direction, 'rtl')
+      notStrictEqual(term, original)
+    })
+
     it('should create a clone of the given Literal with datatype', () => {
       const original = factory.literal('example', factory.namedNode('http://example.org/'))
 


### PR DESCRIPTION
## Summary
- `factory.fromTerm()` / `factory.fromQuad()` cloned a Literal by forwarding only `original.language` as a plain string, so the `direction` property (and the `dirLangString` datatype) was silently dropped when cloning a directional literal.
- Pass the `{ language, direction }` form to `factory.literal()` when the original has a language, preserving `direction` through the clone.